### PR TITLE
fix: changed name of password field to match devise conventions

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -16,7 +16,7 @@
     country: "Country#{i}",
     username: "user#{i + 1}", # Start at user1 to avoid user0
     email: "user#{i + 1}@example.com",
-    password_digest: "somepassworddigest#{i + 1}"
+    password: "somepassword#{i + 1}"
   )
 end
 users = User.all


### PR DESCRIPTION
# Description

Renamed the field we are seeding from 'password_digest' to 'password' to match devise gem conventions and fix rails db:seed error

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] NA

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

