### PR TITLE
[feat] Styled authentication views and navbar

### DIFF
--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,16 +1,28 @@
-<h2>Forgot your password?</h2>
-
-<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
-
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+<div class="flex min-h-full flex-col justify-center px-6 py-12 lg:px-8">
+  <div class="sm:mx-auto sm:w-full sm:max-w-sm">
+    <h1 class="mt-10 text-center text-4xl font-bold leading-9 tracking-tight text-gray-900">
+      <a href="/">
+        Matt's Marketplace
+      </a>
+    </h1>
+    <h2 class="mt-4 text-center text-2xl font-bold leading-9 tracking-tight text-gray-900">Reset password</h2>
   </div>
 
-  <div class="actions">
-    <%= f.submit "Send me reset password instructions" %>
-  </div>
-<% end %>
+  <div class="mt-10 sm:mx-auto sm:w-full sm:max-w-sm">
+    <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
+      <%= render "devise/shared/error_messages", resource: resource %>
+      <div>
+        <%= f.label :email, class: "block text-sm font-medium leading-6 text-gray-900" %>
+        <div class="mt-2">
+          <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "block w-full rounded-md border-0 py-1.5 px-3 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6" %>
+        </div>
+      </div>
+      <br>
 
-<%= render "devise/shared/links" %>
+      <div class="actions">
+        <%= f.submit "Send reset instructions", class: "flex w-full justify-center rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-semibold leading-6 text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"%>
+      </div>
+    <% end %>
+    <%= render "devise/shared/links" %>
+  </div>
+</div>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,29 +1,49 @@
-<h2>Sign up</h2>
-
-<%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
-
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+<div class="flex min-h-full flex-col justify-center px-6 py-12 lg:px-8">
+  <div class="sm:mx-auto sm:w-full sm:max-w-sm">
+    <h1 class="mt-10 text-center text-4xl font-bold leading-9 tracking-tight text-gray-900">
+      <a href="/">
+        Matt's Marketplace
+      </a>
+    </h1>
+    <h2 class="mt-4 text-center text-2xl font-bold leading-9 tracking-tight text-gray-900">Sign up</h2>
   </div>
 
-  <div class="field">
-    <%= f.label :password %>
-    <% if @minimum_password_length %>
-    <em>(<%= @minimum_password_length %> characters minimum)</em>
-    <% end %><br />
-    <%= f.password_field :password, autocomplete: "new-password" %>
-  </div>
+  <div class="mt-10 sm:mx-auto sm:w-full sm:max-w-sm">
+    <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
+      <%= render "devise/shared/error_messages", resource: resource %>
+      <div>
+        <%= f.label :email, class: "block text-sm font-medium leading-6 text-gray-900" %>
+        <div class="mt-2">
+          <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "block w-full rounded-md border-0 py-1.5 px-2 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6" %>
+        </div>
+      </div>
 
-  <div class="field">
-    <%= f.label :password_confirmation %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
-  </div>
+      <div>
+        <div class="flex items-center justify-between">
+          <%= f.label :password, class: "block text-sm font-medium leading-6 text-gray-900" %>
+          <% if @minimum_password_length %>
+            <em>(<%= @minimum_password_length %> characters minimum)</em>
+          <% end %>
+        </div>
+        <div class="mt-2">
+          <%= f.password_field :password, autocomplete: "new-password", class: "block w-full rounded-md border-0 py-1.5 px-2 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6"%>
+        </div>
+      </div>
 
-  <div class="actions">
-    <%= f.submit "Sign up" %>
-  </div>
-<% end %>
+      <div>
+        <div class="flex items-center justify-between">
+          <%= f.label :password_confirmation, class: "block text-sm font-medium leading-6 text-gray-900" %>
+        </div>
+        <div class="mt-2">
+          <%= f.password_field :password_confirmation, autocomplete: "new-password", class: "block w-full rounded-md border-0 py-1.5 px-2 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6"%>
+        </div>
+      </div>
+      <br>
 
-<%= render "devise/shared/links" %>
+      <div class="actions">
+          <%= f.submit "Sign up", class: "flex w-full justify-center rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-semibold leading-6 text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"%>
+      </div>
+    <% end %>
+    <%= render "devise/shared/links" %>
+  </div>
+</div>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,26 +1,46 @@
-<h2>Log in</h2>
-
-<%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+<div class="flex min-h-full flex-col justify-center px-6 py-12 lg:px-8">
+  <div class="sm:mx-auto sm:w-full sm:max-w-sm">
+    <h1 class="mt-10 text-center text-4xl font-bold leading-9 tracking-tight text-gray-900">
+      <a href="/">
+        Matt's Marketplace
+      </a>
+    </h1>
+    <h2 class="mt-4 text-center text-2xl font-bold leading-9 tracking-tight text-gray-900">Log in</h2>
   </div>
 
-  <div class="field">
-    <%= f.label :password %><br />
-    <%= f.password_field :password, autocomplete: "current-password" %>
+  <div class="mt-10 sm:mx-auto sm:w-full sm:max-w-sm">
+    <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
+      <div>
+        <%= f.label :email, class: "block text-sm font-medium leading-6 text-gray-900" %>
+        <div class="mt-2">
+          <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "block w-full rounded-md border-0 py-1.5 px-3 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6" %>
+        </div>
+      </div>
+      <br>
+
+      <div>
+        <div class="flex items-center justify-between">
+          <%= f.label :password, class: "block text-sm font-medium leading-6 text-gray-900" %>
+        </div>
+        <div class="mt-2">
+          <%= f.password_field :password, autocomplete: "current-password", class: "block w-full rounded-md border-0 py-1.5 px-3 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6"%>
+        </div>
+      </div>
+
+      <% if devise_mapping.rememberable? %>
+        <div class="field">
+          <%= f.check_box :remember_me %>
+          <%= f.label :remember_me %>
+        </div>
+      <% end %>
+      <br>
+
+      <div class="actions">
+        <%= f.submit "Log in", class: "flex w-full justify-center rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-semibold leading-6 text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"%>
+      </div>
+    <% end %>
+    <%= render "devise/shared/links" %>
   </div>
+</div>
 
-  <% if devise_mapping.rememberable? %>
-    <div class="field">
-      <%= f.check_box :remember_me %>
-      <%= f.label :remember_me %>
-    </div>
-  <% end %>
 
-  <div class="actions">
-    <%= f.submit "Log in" %>
-  </div>
-<% end %>
-
-<%= render "devise/shared/links" %>

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -1,25 +1,41 @@
-<%- if controller_name != 'sessions' %>
-  <%= link_to "Log in", new_session_path(resource_name) %><br />
-<% end %>
-
-<%- if devise_mapping.registerable? && controller_name != 'registrations' %>
-  <%= link_to "Sign up", new_registration_path(resource_name) %><br />
-<% end %>
-
-<%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
-  <%= link_to "Forgot your password?", new_password_path(resource_name) %><br />
-<% end %>
-
-<%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>
-  <%= link_to "Didn't receive confirmation instructions?", new_confirmation_path(resource_name) %><br />
-<% end %>
-
-<%- if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks' %>
-  <%= link_to "Didn't receive unlock instructions?", new_unlock_path(resource_name) %><br />
-<% end %>
-
-<%- if devise_mapping.omniauthable? %>
-  <%- resource_class.omniauth_providers.each do |provider| %>
-    <%= button_to "Sign in with #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider), data: { turbo: false } %><br />
+<div class=" text-center text-sm w-full justify-center">
+  <br>
+  <%- if controller_name != 'sessions' %>
+    <p class="text-indigo-600 hover:text-indigo-500">
+      <%= link_to "Log in", new_session_path(resource_name) %><br />
+    </p>
   <% end %>
-<% end %>
+
+  <%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
+    <p class="text-indigo-600 hover:text-indigo-500">
+      <%= link_to "Forgot password?", new_password_path(resource_name) %><br />
+    </p>
+  <% end %>
+
+  <%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>
+    <p class="text-indigo-600 hover:text-indigo-500">
+      <%= link_to "Didn't receive confirmation instructions?", new_confirmation_path(resource_name) %><br />
+    </p>
+  <% end %>
+
+  <%- if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks' %>
+    <p class="text-indigo-600 hover:text-indigo-500" >
+      <%= link_to "Didn't receive unlock instructions?", new_unlock_path(resource_name) %><br />
+    </p>
+  <% end %>
+
+  <%- if devise_mapping.omniauthable? %>
+    <%- resource_class.omniauth_providers.each do |provider| %>
+      <p class="text-indigo-600 hover:text-indigo-500">
+        <%= button_to "Sign in with #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider), data: { turbo: false } %><br />
+      </p>
+    <% end %>
+  <% end %>
+
+  <%- if devise_mapping.registerable? && controller_name != 'registrations' %>
+    <p class="text-indigo-600 hover:text-indigo-500">
+      <%= link_to "Sign up", new_registration_path(resource_name) %><br />
+    </p>
+  <% end %>
+
+</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,16 +1,24 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>MattsMarketplace</title>
+    <title>Matt's Marketplace</title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_importmap_tags %>
+
+    <!-- Link to icons -->
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
+    <!-- Link to tailwind -->
+    <script src="https://cdn.tailwindcss.com"></script>
   </head>
 
   <body>
+    <!-- Navbar -->
+    <%= render "/shared/navbar" %>
+
     <!--This will add the notice and alert flash messages to any view that derives from this view-->
     <!--Required by devise gem-->
     <% if flash[:notice].present? %>
@@ -25,6 +33,8 @@
     <% end %>
 
     <!-- Rest of page content -->
-    <%= yield %>
+    <div class="p-4">
+      <%= yield %>
+    </div>
   </body>
 </html>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -2,12 +2,12 @@
 
 <h1>Welcome to My App</h1>
 
-<% if user_signed_in? %>
-  <div> Welcome <%= current_user.email %> </div>
-  <%= button_to "Sign out", destroy_user_session_path, method: :delete %>
-<% else %>
-  <%= button_to "Sign in", new_user_session_path %>
-<% end %>
+<%# if user_signed_in? %>
+<!--  <div> Welcome <%#= current_user.email %> </div>-->
+  <%#= button_to "Sign out", destroy_user_session_path, method: :delete %>
+<%# else %>
+  <%#= button_to "Sign in", new_user_session_path %>
+<%# end %>
 
 <p>Use the buttons below to navigate to the items or users page.</p>
 

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -1,0 +1,47 @@
+
+<header class="header sticky top-0 bg-white shadow-md flex items-center justify-between px-8 py-02">
+    <!-- logo -->
+    <!-- navigation -->
+  <nav class="w-9/12 flex nav text-lg">
+    <h1 class="text-4xl pr-4 py-4 self-center font-bold whitespace-nowrap align-baseline">
+      <a href="/">
+        Matt's
+      </a>
+    </h1>
+    <ul class="flex items-left align-baseline">
+      <li class="px-2 pb-1 pt-7 border-b-2 border-green-500 border-opacity-0 hover:border-opacity-100 hover:text-green-500 duration-200 cursor-pointer active">
+          <%= link_to 'Buy', buyers_path, method: :get %>
+      </li>
+      <li class="px-2 pb-1 pt-7 border-b-2 border-green-500 border-opacity-0 hover:border-opacity-100 hover:text-green-500 duration-200 cursor-pointer">
+          <%= link_to 'Sell', items_path, method: :get %>
+      </li>
+    </ul>
+  </nav>
+
+    <!-- buttons --->
+    <div class="w-3/12 flex justify-end">
+      <ul class="flex items-right right-2">
+        <% if user_signed_in? %>
+          <li class="px-3  pb-2 pt-8 border-b-2 border-green-500 border-opacity-0 hover:border-opacity-100 hover:text-green-500 duration-200 cursor-pointer">
+            <a href="/">
+              <i class="fa fa-user-circle-o" aria-hidden="true"></i>
+            </a>
+          </li>
+          <li class="px-3 pb-3 pt-8 border-b-2 border-green-500 border-opacity-0 hover:border-opacity-100 hover:text-green-500 duration-200 cursor-pointer">
+            <a href="/">
+              <i class="fa fa-shopping-cart" aria-hidden="true"></i>
+            </a>
+          </li>
+          <li class="px-2 pb-3 pt-8 border-b-2 border-green-500 border-opacity-0 hover:border-opacity-100 hover:text-green-500 duration-200 cursor-pointer">
+            <%= button_to "Sign out", destroy_user_session_path, method: :delete %>
+          </li>
+        <% else %>
+          <li class="px-3 pb-3 pt-8 border-b-2 border-green-500 border-opacity-0 hover:border-opacity-100 hover:text-green-500 duration-200 cursor-pointer">
+            <button type="button">
+              <%= link_to "Log in", new_user_session_path, :method => :get %>
+            </button>
+          </li>
+        <% end %>
+      </ul>
+    </div>
+</header>


### PR DESCRIPTION
# Description

Adds a navbar with some styling to every page in the app through the application layout. Adds new styling to log in, sign up, and reset password screens.  Uses tailwind css. I'll add a link to the [cheatsheet](https://nerdcave.com/tailwind-cheat-sheet) I was using to the wiki. The style that I used doesn't have to be the one we go with. I just thought it looked good enough and was not too hard to make.

## Views
![Matt_s Marketplace](https://github.com/uiowahjmjohnsonselt2023/matts-marketplace/assets/42824421/b16b9af6-1fd4-469f-a8c4-33dc669d6390)
![Matt_s Marketplace (1)](https://github.com/uiowahjmjohnsonselt2023/matts-marketplace/assets/42824421/021fd71c-f26d-470d-a81a-9dccc8fc239f)
![Matt_s Marketplace (2)](https://github.com/uiowahjmjohnsonselt2023/matts-marketplace/assets/42824421/a64d6b8c-4c43-4064-a333-a8d7f076401e)
  

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Only the styling changed, so all of our previous tests remain the same and still work.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

