### PR TITLE
fix: fixed buyers detail view so people can view buyers without ratings

### DIFF
--- a/app/views/buyers/show.html.erb
+++ b/app/views/buyers/show.html.erb
@@ -60,7 +60,7 @@
       <h2 class="p-4 text-blue-700">
         <%= @item.user.username %>
       </h2>
-      <% if not @item.user.rating  %>
+      <% if @item.user.rating.nil? %>
         <h1 class="p-4 bg-green-100 text-gray-600">
           Feedback Rating: NA
         </h1>


### PR DESCRIPTION
# Description
Tweaked `buyers/show.html.erb` so we can see users with rating 'NA'. Users have rating 'NA' when they do not have a rating yet. 

Fixes #45

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

