### PR TITLE
Image Upload and Display via Simple File Upload

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -230,7 +230,7 @@ GEM
     net-smtp (0.4.0)
       net-protocol
     nio4r (2.6.1)
-    nokogiri (1.15.5-x86_64-darwin)
+    nokogiri (1.15.5-x86_64-linux)
       racc (~> 1.4)
     notiffany (0.1.3)
       nenv (~> 0.1)
@@ -374,6 +374,7 @@ GEM
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
     sqlite3 (1.6.8-x86_64-darwin)
+    sqlite3 (1.6.8-x86_64-linux)
     stimulus-rails (1.3.0)
       railties (>= 6.0.0)
     stringio (3.0.9)
@@ -406,6 +407,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-23
+  x86_64-linux
 
 DEPENDENCIES
   bootsnap

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -151,6 +151,9 @@ GEM
     eventmachine (1.2.7)
     factory_bot (6.4.2)
       activesupport (>= 5.0.0)
+    factory_bot_rails (6.4.2)
+      factory_bot (~> 6.4)
+      railties (>= 5.0.0)
     faker (3.2.2)
       i18n (>= 1.8.11, < 2)
     faraday (2.7.12)
@@ -418,6 +421,7 @@ DEPENDENCIES
   debug
   devise (~> 4.9)
   factory_bot (~> 6.4)
+  factory_bot_rails
   faker
   guard-livereload
   guard-rspec

--- a/app/views/chats/_item_card.html.erb
+++ b/app/views/chats/_item_card.html.erb
@@ -1,4 +1,4 @@
-<%= link_to chat.item do %>
+<%= link_to send("buyer_path", chat.item) do %>
   <div class="flex sticky top-16 z-50 items-left h-16 border border-gray-200 shadow bg-opacity-95 bg-gray-100">
     <img class="object-cover w-auto rounded-t-lg h-full max-w-xs max-h-10 p-2 " src="<%= chat.item.image_url %>" alt="">
     <div class="flex flex-col justify-start px-4 mt-1 leading-normal">

--- a/app/views/chats/_item_card.html.erb
+++ b/app/views/chats/_item_card.html.erb
@@ -1,6 +1,6 @@
 <%= link_to send("buyer_path", chat.item) do %>
   <div class="flex sticky top-16 z-50 items-left h-16 border border-gray-200 shadow bg-opacity-95 bg-gray-100">
-    <img class="object-cover w-auto rounded-t-lg h-full max-w-xs max-h-10 p-2 " src="<%= chat.item.image_url %>" alt="">
+    <img class="object-cover mt-auto mb-auto ml-4 w-auto rounded-lg h-full max-w-xs max-h-10 " src="<%= chat.item.image_url %>" alt="">
     <div class="flex flex-col justify-start px-4 mt-1 leading-normal">
       <h5 class="mb-0 text-xl font-bold tracking-tight text-gray-900"><%= chat.item.description %></h5>
       <div class="flex items-center mb-2 justify-between">

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -19,7 +19,7 @@
       <div class="mb-2">
         <%= f.label :image_url, class: "block text-sm font-medium leading-6 text-gray-900" %>
         <div class="mt-1">
-          <%= f.text_field :image_url, autofocus: true, class: "block w-full rounded-md border-0 py-1.5 px-3 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6", placeholder: 'Enter image URL' %>
+           <input type="hidden" name="image_url" id="image_url" class="simple-file-upload">
         </div>
       </div>
 

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -19,7 +19,7 @@
       <div class="mb-2">
         <%= f.label :image_url, class: "block text-sm font-medium leading-6 text-gray-900", "Upload Image" %>
         <div class="mt-1">
-          <%= f.hidden_field :image_url, class: "simple-file-upload" %>
+          <%= f.hidden_field :image_url, class: "simple-file-upload", data: { accepted: "image/*", tag: "item", resizeWidth: 200 } %>
         </div>
       </div>
 

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -1,11 +1,4 @@
 <div class="flex min-h-full flex-col justify-center px-6 py-12 lg:px-8">
-  <script>
-    function showUpload() {
-      event.preventDefault();
-      location.reload(true);
-    }
-  </script>
-
   <div class="mt-6 sm:mx-auto sm:w-full sm:max-w-sm">
     <h2 class="my-5 text-2xl font-bold leading-9 tracking-tight text-gray-900">Sell new item</h2>
     <%= form_for @item do |f| %>
@@ -46,26 +39,50 @@
         <% end %>
       </div>
 
-      <div class="mb-2">
-        <%= f.label :featured, class: "block text-sm font-medium leading-6 text-gray-900" %>
-        <div class="mt-1">
-          <%= f.check_box :featured, id: "featured-checkbox" %>
-          Feature item
-        </div>
-      </div>
-
-      <div class="mb-2" id="featured-amount-field" style="display: none;">
-        <%= f.label :featured_amount_paid, class: "block text-sm font-medium leading-6 text-gray-900" %>
-        <div class="mt-1">
-          <%= f.text_field :featured_amount_paid, class: "block w-full rounded-md border-0 py-1.5 px-3 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6", placeholder: 'Enter amount' %>
-        </div>
-      </div>
-
-      <%= javascript_include_tag 'items/feature-item' %>
-
       <div class = 'flex flex-col items-center mt-3'>
         <%= f.submit value: 'Sell Item', class: 'w-56 text-white ml-4 focus:ring-4 focus:outline-none font-medium rounded-lg text-sm px-8 py-2 bg-blue-600 hover:bg-blue-700 focus:ring-blue-800' %>
       </div>
     <% end %>
   </div>
+
+  <script>
+    function showUpload() {
+      event.preventDefault();
+      location.reload(true);
+    }
+
+    document.addEventListener('DOMContentLoaded', function() {
+      restoreFormData();
+      window.addEventListener('beforeunload', function(event) {
+        // Save form data before the page is unloaded
+        console.log("Saving Form");
+        saveFormData();
+        console.log(sessionStorage.getItem('formData'));
+      });
+    });
+
+    function saveFormData() {
+      const formData = {
+        price: document.getElementById('item_price').value,
+        description: document.getElementById('item_description').value,
+        category: document.getElementById('item_category_id').value,
+        for_sale: document.getElementById('item_for_sale').value,
+      };
+
+      sessionStorage.setItem('formData', JSON.stringify(formData));
+    }
+
+    function restoreFormData() {
+      const storedData = sessionStorage.getItem('formData');
+
+      if (storedData) {
+        const formData = JSON.parse(storedData);
+        document.getElementById('item_price').value = formData.price;
+        document.getElementById('item_description').value = formData.description;
+        document.getElementById('item_category_id').value = formData.category;
+        document.getElementById('item_for_sale').value = formData.for_sale;
+      }
+    }
+  </script>
+
 </div>

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -17,7 +17,7 @@
       </div>
 
       <div class="mb-2">
-        <%= f.label :image_url, class: "block text-sm font-medium leading-6 text-gray-900" %>
+        <%= f.label :image_url, class: "block text-sm font-medium leading-6 text-gray-900", "Upload Image" %>
         <div class="mt-1">
           <%= f.hidden_field :image_url, class: "simple-file-upload" %>
         </div>

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -1,4 +1,11 @@
 <div class="flex min-h-full flex-col justify-center px-6 py-12 lg:px-8">
+  <script>
+    function showUpload() {
+      event.preventDefault();
+      location.reload(true);
+    }
+  </script>
+
   <div class="mt-6 sm:mx-auto sm:w-full sm:max-w-sm">
     <h2 class="my-5 text-2xl font-bold leading-9 tracking-tight text-gray-900">Sell new item</h2>
     <%= form_for @item do |f| %>
@@ -15,9 +22,10 @@
           <%= f.text_field :description, autofocus: true, class: "block w-full rounded-md border-0 py-1.5 px-3 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6", placeholder: 'Enter description' %>
         </div>
       </div>
-
+      <button onclick="showUpload()" class="w-56 text-black focus:ring-4 focus:outline-none font-medium rounded-lg text-sm px-8 py-2 bg-gray-200 hover:bg-gray-400 focus:ring-gray-200">
+        Upload Image
+      </button>
       <div class="mb-2">
-        <%= f.label :image_url, class: "block text-sm font-medium leading-6 text-gray-900" %>
         <div class="mt-1">
           <%= f.hidden_field :image_url, class: "simple-file-upload" %>
         </div>

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -55,9 +55,7 @@
       restoreFormData();
       window.addEventListener('beforeunload', function(event) {
         // Save form data before the page is unloaded
-        console.log("Saving Form");
         saveFormData();
-        console.log(sessionStorage.getItem('formData'));
       });
     });
 

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -17,9 +17,9 @@
       </div>
 
       <div class="mb-2">
-        <%= f.label :image_url, class: "block text-sm font-medium leading-6 text-gray-900", "Upload Image" %>
+        <%= f.label :image_url, class: "block text-sm font-medium leading-6 text-gray-900" %>
         <div class="mt-1">
-          <%= f.hidden_field :image_url, class: "simple-file-upload", data: { accepted: "image/*", tag: "item", resizeWidth: 200 } %>
+          <%= f.hidden_field :image_url, class: "simple-file-upload" %>
         </div>
       </div>
 

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -19,7 +19,7 @@
       <div class="mb-2">
         <%= f.label :image_url, class: "block text-sm font-medium leading-6 text-gray-900" %>
         <div class="mt-1">
-           <input type="hidden" name="image_url" id="image_url" class="simple-file-upload">
+          <%= f.hidden_field :image_url, class: "simple-file-upload" %>
         </div>
       </div>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -36,6 +36,9 @@
           opacity: 0;
       }
     </style>
+
+    <!-- Simple File Upload -->
+     <script src="https://app.simplefileupload.com/buckets/<%= ENV['SIMPLE_FILE_UPLOAD_KEY'] %>.js"></script>
   </head>
 
   <body>

--- a/app/views/sellers/index.html.erb
+++ b/app/views/sellers/index.html.erb
@@ -74,8 +74,15 @@
   <% else %>
     <h3 class="text-2xl font-semibold text-start m-4"> No items sold yet.</h3>
     <div class="mb-2">
-      <%= link_to 'Add New Item', new_item_path, class: 'text-white ml-4 focus:ring-4 focus:outline-none font-medium rounded-lg text-sm px-8 py-2 bg-blue-600 hover:bg-blue-700 focus:ring-blue-800' %>
+      <%= link_to 'Add New Item', new_item_path, onclick: 'clearItemForm()', class: 'text-white ml-4 focus:ring-4 focus:outline-none font-medium rounded-lg text-sm px-8 py-2 bg-blue-600 hover:bg-blue-700 focus:ring-blue-800' %>
     </div>
   <% end %>
+  <script>
+    clearItemForm() {
+      if (sessionStorage.getItem('formData') !== null) {
+        sessionStorage.removeItem('formData');
+      }
+    }
+  </script>
 
 </div>

--- a/app/views/shared/_itemcard.html.erb
+++ b/app/views/shared/_itemcard.html.erb
@@ -1,7 +1,7 @@
 <div class="w-full max-w-sm bg-white border border-gray-200 rounded-lg shadow flex flex-col">
   <div class="flex-grow-3 flex">
     <a href="#" class="flex-grow">
-      <img class="p-8 rounded-t-lg" src="#" alt="product image" />
+      <img class="p-8 rounded-t-lg" src="<%= item.image_url %>" alt="product image" />
     </a>
 
     <!-- Star button -->

--- a/app/views/shared/_itemcard.html.erb
+++ b/app/views/shared/_itemcard.html.erb
@@ -1,7 +1,7 @@
 <div class="w-full max-w-sm bg-white border border-gray-200 rounded-lg shadow flex flex-col">
   <div class="flex-grow-3 flex">
-    <a href="#" class="flex-grow">
-      <img class="p-8 rounded-t-lg" src="<%= item.image_url %>" alt="product image" />
+    <a href="<%= item.image_url %>" class="flex-grow aspect-w-1 aspect-h-1">
+      <img class="w-full object-cover p-8 rounded-t-lg" src="<%= item.image_url %>" alt="product image" />
     </a>
 
     <!-- Star button -->

--- a/app/views/shared/_itemcard.html.erb
+++ b/app/views/shared/_itemcard.html.erb
@@ -1,7 +1,9 @@
 <div class="w-full max-w-sm bg-white border border-gray-200 rounded-lg shadow flex flex-col">
   <div class="flex-grow-3 flex">
-    <a href="<%= item.image_url %>" class="flex-grow aspect-w-1 aspect-h-1">
-      <img class="w-full object-cover p-8 rounded-t-lg" src="<%= item.image_url %>" alt="product image" />
+    <a href="<%= item.image_url %>" class="flex-grow">
+      <div class="w-[200px] h-[200px]">
+        <img class="object-cover p-8 rounded-t-lg" src="<%= item.image_url %>" alt="product image" />
+      </div>
     </a>
 
     <!-- Star button -->

--- a/app/views/shared/_itemcard.html.erb
+++ b/app/views/shared/_itemcard.html.erb
@@ -1,22 +1,22 @@
 <div class="w-full max-w-sm bg-white border border-gray-200 rounded-lg shadow flex flex-col">
   <div class="flex-grow-3 flex">
-    <a href="<%= item.image_url %>" class="flex-grow">
-      <div class="w-[200px] h-[200px]">
-        <img class="object-cover p-8 rounded-t-lg" src="<%= item.image_url %>" alt="product image" />
+    <a href="<%= item.image_url %>" class="flex justify-center w-full">
+      <div class="flex justify-center h-[200px] overflow-hidden">
+        <img class="object-cover mt-4 rounded-lg" src="<%= item.image_url %>" alt="product image" />
       </div>
     </a>
 
+  </div>
+
+  <!--Item Card body -->
+  <div class="px-5 pb-5 flex-grow-3 relative">
     <!-- Star button -->
-    <div class="flex-none">
+    <div class="flex-none absolute top-0 right-0 m-4">
       <% star_color = user_signed_in? && current_user.wishlist_items.include?(item) ? 'text-yellow-400' : 'text-gray-400' %>
       <%= button_to toggle_wishlist_path(item_id: item.id), remote: true, method: :post do %>
         <i class="fa fa-star fa-lg p-4 fill-current <%= star_color %> hover:text-yellow-500 star-button"></i>
       <% end %>
     </div>
-  </div>
-
-  <!--Item Card body -->
-  <div class="px-5 pb-5 flex-grow-3">
     <%= link_to defined?(path_keyword) ?
                   send("#{path_keyword}_path", item) :
                   item_path(item) do %>


### PR DESCRIPTION
# Description

I will do more to get this integrated everywhere but here is an initial pull request with examples so that people can use the image upload in their ongoing work.

The upload box may need a refresh on the page to appear...working on that.

To add an upload box where users can put new images just add this hidden_field to form f, with :image_url corresponding to your URL column in the model.  This will automatically put the uploaded image into our bucket and store the URL with the created record on form submission.

```
<%= f.hidden_field :image_url, class: "simple-file-upload" %>
```

To include an image in your view, just reference that image's URL through the model.
```
<img src="<%= item.image_url %>" alt="product image" />

```


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

