### PR TITLE
fix: change db seed to make rating nil for root admin

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -46,7 +46,8 @@ User.create!(
   username: "hjmjohnson",
   email: "hans@uiowa.edu",
   password: "adminpassword",
-  rating: 5,
+  image_url: "https://cdn-q16l3wg5.files-simplefileupload.com/static/blobs/proxy/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBeWVtQXc9PSIsImV4cCI6bnVsbCwicHVyIjoiYmxvYl9pZCJ9fQ==--50596c1e558029a96148b06db9d96101c410dbb8/hans.jpg",
+  rating: nil,
   admin: true,
   root_admin: true
   )


### PR DESCRIPTION
# Description

Fix the db:seed to prevent errors when getting average rating for root_admin


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

N/A

# Checklist:

- [x]  My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

